### PR TITLE
feat(net): 2: migrated to .NET 5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 5.0.301
     - name: Install dependencies
       run: dotnet restore
     - name: Build
@@ -27,4 +27,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: app
-        path: src/Codecagon.Tools.AzureFunctions.OpenAPIGenerator/bin/Release/netcoreapp3.1/
+        path: src/Codecagon.Tools.AzureFunctions.OpenAPIGenerator/bin/Release/net5.0/

--- a/src/Codecagon.Tools.AzureFunctions.OpenAPIGenerator/.nuspec
+++ b/src/Codecagon.Tools.AzureFunctions.OpenAPIGenerator/.nuspec
@@ -5,7 +5,7 @@
         <version>%%version%%</version>
         <authors>Stepan Prokipchyn</authors>
         <owners>stepan.prokipchyn</owners>
-        <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+        <license type="expression">Apache-2.0</license>
         <projectUrl>https://github.com/codecagon/AzureFunctions.OpenAPIGenerator/</projectUrl>
         <description>OpenAPI generation tool for Azure Functions</description>
 <!--        <releaseNotes>First release</releaseNotes>-->
@@ -13,9 +13,9 @@
 <!--        <tags>VIPS exe file</tags>-->
     </metadata>
     <files>
-        <file src=".\bin\Release\netcoreapp3.1\*.*" target="tools" />
+        <file src=".\bin\Release\net5.0\*.*" target="tools" />
         <file src=".\dist\*.*" target="dist/swagger" />
-        <file src=".\bin\Release\netcoreapp3.1\*.*" target="lib\netcoreapp3.1" />
+        <file src=".\bin\Release\net5.0\*.*" target="lib\net5.0" />
         <file src=".\Codecagon.Tools.AzureFunctions.OpenAPIGenerator.targets" target="build\Codecagon.Tools.AzureFunctions.OpenAPIGenerator.targets" />
     </files>
 </package>

--- a/src/Codecagon.Tools.AzureFunctions.OpenAPIGenerator/Codecagon.Tools.AzureFunctions.OpenAPIGenerator.csproj
+++ b/src/Codecagon.Tools.AzureFunctions.OpenAPIGenerator/Codecagon.Tools.AzureFunctions.OpenAPIGenerator.csproj
@@ -1,18 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <OutputType>Exe</OutputType>
         <RootNamespace>Tools.OpenAPIGenerator</RootNamespace>
         <NuspecFile>./.nuspec</NuspecFile>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
       <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
       <PackageReference Include="Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration" Version="2.0.0-beta02" />
-      <PackageReference Include="MoreLinq.Portable" Version="1.4.0" />
-      <PackageReference Include="System.Reflection.MetadataLoadContext" Version="5.0.0-preview.8.20407.11" />
+      <PackageReference Include="System.Reflection.MetadataLoadContext" Version="5.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/Codecagon.Tools.AzureFunctions.OpenAPIGenerator/ISwaggerGenerator.cs
+++ b/src/Codecagon.Tools.AzureFunctions.OpenAPIGenerator/ISwaggerGenerator.cs
@@ -1,11 +1,9 @@
-using Microsoft.AspNetCore.Mvc;
-
 namespace Codecagon.Tools.AzureFunctions.OpenAPIGenerator
 {
     public interface ISwaggerGenerator
     {
 
-        IActionResult Render(string fileName);
+        RenderedDocument Render(string fileName);
 
     }
 }

--- a/src/Codecagon.Tools.AzureFunctions.OpenAPIGenerator/RenderedDocument.cs
+++ b/src/Codecagon.Tools.AzureFunctions.OpenAPIGenerator/RenderedDocument.cs
@@ -1,0 +1,21 @@
+using System.IO;
+
+namespace Codecagon.Tools.AzureFunctions.OpenAPIGenerator
+{
+    public class RenderedDocument
+    {
+        public string FileName { get; }
+        
+        public string MimeType { get; }
+
+        public Stream Content { get; }
+
+        public RenderedDocument(string fileName, string mimeType, Stream content)
+        {
+            FileName = fileName;
+            MimeType = mimeType;
+            Content = content;
+        }
+
+    }
+}

--- a/src/Codecagon.Tools.AzureFunctions.OpenAPIGenerator/SwaggerGenerator.cs
+++ b/src/Codecagon.Tools.AzureFunctions.OpenAPIGenerator/SwaggerGenerator.cs
@@ -1,6 +1,4 @@
-using System.IO;
 using System.Reflection;
-using Microsoft.AspNetCore.Mvc;
 
 namespace Codecagon.Tools.AzureFunctions.OpenAPIGenerator
 {
@@ -14,15 +12,10 @@ namespace Codecagon.Tools.AzureFunctions.OpenAPIGenerator
             _assembly = assembly;
         }
         
-        public IActionResult Render(string fileName)
+        public RenderedDocument Render(string fileName)
         {
             using var stream = _assembly.GetManifestResourceStream($"Swagger.{fileName}");
-            using var reader = new StreamReader(stream!);
-            
-            return new ContentResult {
-                Content = reader.ReadToEnd(),
-                ContentType = MimeUtils.GetMimeType(fileName)
-            };
+            return new(fileName, MimeUtils.GetMimeType(fileName), stream);
         }
     }
 }


### PR DESCRIPTION
Project:
* migrated on .NET 5
* removed MVC Core dependency, because isolated functions do not support IActionResult anymore
* removed MoreLinq dependency because DistinctBy could be easily replaced with GroupBy
* introduced RenderedDocument instead of IActionResult

ISwaggerGenerator, SwaggerGenerator:
* used RenderedDocument instead of IActionResult, because isolated functions do not support it anymore

Program:
* use `FunctionAttribute` instead of `FunctionNameAttribute` as per changes in Azure Functions
* use `HttpRequestData` instead of `HttpRequest` as per changes in Azure Functions
* used `GroupBy,Select` instead of `DistinctBy`
* removed `IActionResult` unwrapping

.nuspec:
* removed deprecated `licenseUrl` tag
* updated paths

BREAKING CHANGES:
* previous version support dropped
* API changes